### PR TITLE
Make empty node mean depot

### DIFF
--- a/vrp.html
+++ b/vrp.html
@@ -115,7 +115,7 @@
               path.push("d");
           for (var i = 0; i < path.length; i++) {
               path[i] = path[i].trim()
-              if (path[i] == "d")
+              if (path[i] == "d" || path[i] == "")
                   path[i] = 0;
               else if (!isNaN(path[i])) {
                   path[i] = parseInt(path[i])


### PR DESCRIPTION
When typing `1,2,,3` the program used to crash, we now take that to mean `1,2,d,3`